### PR TITLE
GitHub ActionsでCI設定

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -12,9 +12,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3307/memos
-      SPRING_DATASOURCE_USER_NAME: user
-      SPRING_DATASOURCE_USER_PASS: password
+      SPRING_DATASOURCE_URL: ${{secrets.SPRING_DATASOURCE_URL}}
+      SPRING_DATASOURCE_USER_NAME: ${{secrets.SPRING_DATASOURCE_NAME}}
+      SPRING_DATASOURCE_USER_PASS: ${{secrets.SPRING_DATASOURCE_PASS}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,10 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3307/memos
-      SPRING_DATASOURCE_USER_NAME: user
-      SPRING_DATASOURCE_USER_PASS: password
 
     steps:
       - name: Checkout
@@ -36,3 +32,7 @@ jobs:
         id: test
         run: ./gradlew test
         if: always()
+        env:
+          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+          SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
+          SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,22 +8,22 @@ on:
   push:
     branches: [ "main" ]
 
-env:
-  SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
-  SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
-  SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
-
-run: |
-  echo ${SPRING_DATASOURCE_URL}
-  echo ${SPRING_DATASOURCE_USER_NAME}
-  echo ${SPRING_DATASOURCE_USER_PASS}
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+        env:
+          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+          SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
+          SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
+
+        run: |
+          echo ${SPRING_DATASOURCE_URL}
+          echo ${SPRING_DATASOURCE_USER_NAME}
+          echo ${SPRING_DATASOURCE_USER_PASS}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -28,3 +28,4 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: test
+          cache-disabled: true

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - run: |
+          echo "this is Spring datasource url = ${{SPRING_DATASOURCE_URL}}"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -32,7 +34,7 @@ jobs:
         id: test
         run: ./gradlew test
         if: always()
-        env:
-          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
-          SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
-          SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
+#        env:
+#          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+#          SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
+#          SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -9,17 +9,17 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'zulu'
 
       - name: start docker
         run: docker compose up -d

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,13 +1,12 @@
 name: Unit Testing by Github Actions
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
       - 'feature/*'
+  push:
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'temurin'
 
       - name: start docker

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: start docker
         run: docker compose up -d

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,15 +15,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: load environment variables
+        run:
+          echo ${SPRING_DATASOURCE_URL} ${SPRING_DATASOURCE_USER_NAME} ${SPRING_DATASOURCE_USER_PASS}
+
         env:
           SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
           SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
           SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
-
-        run: |
-          echo ${SPRING_DATASOURCE_URL}
-          echo ${SPRING_DATASOURCE_USER_NAME}
-          echo ${SPRING_DATASOURCE_USER_PASS}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,12 +11,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3307/memos
+      SPRING_DATASOURCE_USER_NAME: user
+      SPRING_DATASOURCE_USER_PASS: password
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - run: |
-          echo "this is Spring datasource url = ${{SPRING_DATASOURCE_URL}}"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -34,7 +36,3 @@ jobs:
         id: test
         run: ./gradlew test
         if: always()
-#        env:
-#          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
-#          SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
-#          SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,25 @@
+name: Unit Testing by Github Actions
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'feature/*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+              java-version: '17'
+              distribution: 'zulu'
+      - name: start docker
+        run: docker-compose up -d
+      - name: Run test with Gradle
+        uses: eskatos/gradle-command-action@v1
+        with:
+          argument: test

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3307/memos
+      SPRING_DATASOURCE_USER_NAME: user
+      SPRING_DATASOURCE_USER_PASS: password
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,5 +33,5 @@ jobs:
 
       - name: Test with Gradle
         id: test
-        run: ./gradlew test
+        run: gradle test
         if: always()

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -22,9 +22,9 @@ jobs:
         run: docker compose up -d
 
       - name: Add exec Permission
-        run: chmod +x ./gradlew
+        run: chmod +x gradlew
 
-      - name: run test
+      - name: Run test with Gradle
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: test
+          argument: test

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -7,7 +7,7 @@ on:
       - 'feature/*'
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,13 +11,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      SPRING_DATASOURCE_URL: ${{secrets.SPRING_DATASOURCE_URL}}
-      SPRING_DATASOURCE_USER_NAME: ${{secrets.SPRING_DATASOURCE_NAME}}
-      SPRING_DATASOURCE_USER_PASS: ${{secrets.SPRING_DATASOURCE_PASS}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+        env:
+          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+          SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
+          SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,10 +15,15 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-              java-version: '17'
-              distribution: 'zulu'
+          java-version: '17'
+          distribution: 'zulu'
+
       - name: start docker
-        run: docker-compose up -d
+        run: docker compose up -d
+
+      - name: Add exec Permission
+        run: chmod +x gradlew
+
       - name: Run test with Gradle
         uses: eskatos/gradle-command-action@v1
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,17 +8,22 @@ on:
   push:
     branches: [ "main" ]
 
+env:
+  SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+  SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
+  SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
+
+run: |
+  echo ${SPRING_DATASOURCE_URL}
+  echo ${SPRING_DATASOURCE_USER_NAME}
+  echo ${SPRING_DATASOURCE_USER_PASS}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-        env:
-          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
-          SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
-          SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
+      - 'feature/*'
 
 jobs:
   build:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,6 +25,6 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Run test with Gradle
-        id: test
-        run: ./gradlew test
-        if: always()
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: test

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -22,7 +22,7 @@ jobs:
         run: docker compose up -d
 
       - name: Add exec Permission
-        run: chmod +x gradlew
+        run: chmod +x ./gradlew
 
       - name: Run test with Gradle
         id: test

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    run:
-      echo ${SPRING_DATASOURCE_URL} ${SPRING_DATASOURCE_USER_NAME} ${SPRING_DATASOURCE_USER_PASS}
-
     env:
       SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
       SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,18 +11,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    run:
+      echo ${SPRING_DATASOURCE_URL} ${SPRING_DATASOURCE_USER_NAME} ${SPRING_DATASOURCE_USER_PASS}
+
+    env:
+      SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+      SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
+      SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: load environment variables
-        run:
-          echo ${SPRING_DATASOURCE_URL} ${SPRING_DATASOURCE_USER_NAME} ${SPRING_DATASOURCE_USER_PASS}
-
-        env:
-          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
-          SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
-          SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-          cache: 'gradle'
 
       - name: start docker
         run: docker compose up -d

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -12,9 +12,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
-      SPRING_DATASOURCE_USER_NAME: ${{ secrets.SPRING_DATASOURCE_NAME }}
-      SPRING_DATASOURCE_USER_PASS: ${{ secrets.SPRING_DATASOURCE_PASS }}
+      SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3307/memos
+      SPRING_DATASOURCE_USER_NAME: user
+      SPRING_DATASOURCE_USER_PASS: password
 
     steps:
       - name: Checkout

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
+          cache: 'gradle'
 
       - name: start docker
         run: docker compose up -d
@@ -25,6 +26,6 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run test with Gradle
-        uses: eskatos/gradle-command-action@v1
-        with:
-          argument: test
+        id: test
+        run: ./gradlew test
+        if: always()

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
-      - 'feature/*'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
       - uses: actions/checkout@v3
 
       - name: Set up JDK 17

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,13 +1,16 @@
 name: Unit Testing by Github Actions
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
       - 'feature/*'
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +27,7 @@ jobs:
       - name: Add exec Permission
         run: chmod +x gradlew
 
-      - name: Run test with Gradle
-        uses: eskatos/gradle-command-action@v1
-        with:
-          argument: test
+      - name: Test with Gradle
+        id: test
+        run: ./gradlew test
+        if: always()

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: start docker
         run: docker compose up -d
@@ -24,8 +24,7 @@ jobs:
       - name: Add exec Permission
         run: chmod +x ./gradlew
 
-      - name: Run test with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: test
-          cache-disabled: true
+      - name: Test with Gradle
+        id: test
+        run: ./gradlew test
+        if: always()

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -33,5 +33,5 @@ jobs:
 
       - name: Test with Gradle
         id: test
-        run: gradle test
+        run: ./gradlew test
         if: always()

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -7,7 +7,7 @@ on:
       - 'feature/*'
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'temurin'
+          distribution: 'zulu'
 
       - name: start docker
         run: docker compose up -d
@@ -24,7 +24,7 @@ jobs:
       - name: Add exec Permission
         run: chmod +x ./gradlew
 
-      - name: Test with Gradle
-        id: test
-        run: ./gradlew test
-        if: always()
+      - name: run test
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: test

--- a/src/test/java/com/rtjavamemoapp/integrationtest/MemoRestApiIntegrationTest.java
+++ b/src/test/java/com/rtjavamemoapp/integrationtest/MemoRestApiIntegrationTest.java
@@ -216,6 +216,6 @@ public class MemoRestApiIntegrationTest {
   @Test
   void 存在しないIDを指定して削除する時のレスポンス内容が正しいこと() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders.delete("/memos/100"))
-        .andExpect(MockMvcResultMatchers.status().isOk());
+        .andExpect(MockMvcResultMatchers.status().isNotFound());
   }
 }

--- a/src/test/java/com/rtjavamemoapp/integrationtest/MemoRestApiIntegrationTest.java
+++ b/src/test/java/com/rtjavamemoapp/integrationtest/MemoRestApiIntegrationTest.java
@@ -216,6 +216,6 @@ public class MemoRestApiIntegrationTest {
   @Test
   void 存在しないIDを指定して削除する時のレスポンス内容が正しいこと() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders.delete("/memos/100"))
-        .andExpect(MockMvcResultMatchers.status().isNotFound());
+        .andExpect(MockMvcResultMatchers.status().isOk());
   }
 }


### PR DESCRIPTION
# GitHub Actions でのCI設定
mainへプッシュした時とプルリクエスト作成時にCIが稼働するよう設定

## 詰まったこと

applications.properies の環境変数が問題でWorkflow 内で読み込めていなかったことで以下のエラーが発生した。

ローカル環境ではプロジェクト内の全てのテストが通過することは確認ずみだが、
GitHubActionsでは以下のエラーになり、Build自体に成功しなかった。
こちらの[Gradle Forum](https://discuss.gradle.org/t/gradle-running-tests-from-another-subproject/39352)の質問と似た事象が起きている。

```
java.lang.IllegalStateException at DefaultCacheAwareContextLoaderDelegate.java:142
        Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException at ConstructorResolver.java:798
            Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException at ConstructorResolver.java:798
                Caused by: org.springframework.beans.factory.BeanCreationException at BeanDefinitionValueResolver.java:377
                    Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException at ConstructorResolver.java:798
                        Caused by: org.springframework.beans.factory.BeanCreationException at ConstructorResolver.java:657
                            Caused by: org.springframework.beans.BeanInstantiationException at SimpleInstantiationStrategy.java:171
                                Caused by: java.lang.IllegalArgumentException at Assert.java:122

FAILURE: Build failed with an exception.
```

## 確認したこと
- JDK 11 17 でも同じエラー
- distribution を変更しても同じエラー
- gradlew testを実行しないCIなら成功する
- WFのキャッシュを削除してもエラーが発生
- ローカルのIntelliJ ではテストは全て成功することを確認
↓
環境変数の観点が抜けていた。ローカルで通るのにGithub Actionsでは通らない。。。。みたいな時には環境変数など確認すると良さそう。