### PR TITLE
MyBatisTestアノテーションへ更新対応

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
+	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'

--- a/src/test/java/com/rtjavamemoapp/infrastructure/mapper/MemoMapperTest.java
+++ b/src/test/java/com/rtjavamemoapp/infrastructure/mapper/MemoMapperTest.java
@@ -7,13 +7,13 @@ import com.rtjavamemoapp.domain.model.Memo;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@MybatisTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MemoMapperTest {
 


### PR DESCRIPTION
DBテストのアノテーションが単体テストにも関わらず @ SpringBootTest を利用していましたが、
DBテストのみを行う上では処理として重たいため @ MyBatisTestへ置き換えを実施。

元々は  MyBatis の Bean が生成されないという問題だったが、依存関係が影響していたようでした。
[mybatis-spring-boot-3.0.0](https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-3.0.0)

バージョンを更新して、アノテーションを変更したところ、無事反映されました。